### PR TITLE
Allow the Resque Redis URL to be configured via an ENV var

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,7 @@
+# Allow overriding Redis URL via ENV vars
+if ENV["REDIS_URL"].present?
+  uri = URI.parse(ENV["REDIS_URL"])
+  Resque.redis = Redis.new(:host => uri.host, :port => uri.port, :password => uri.password)
+else
+  Resque.redis = Redis.new
+end


### PR DESCRIPTION
While attempting to deploy the redis branch it was found that it was not possible to change the Redis URL from the default.  This patch adds a Resque config file that allows the Redis URL to be configured via a REDIS_URL env var, similar to the POSTGRES_URL env var.  It currently does not support changing the Redis database.

Based off https://github.com/stitchfix/resque-brain/blob/master/config/initializers/resque.rb#L7-L12